### PR TITLE
Add OpenPaw

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [CodeSelect](https://github.com/maynetee/codeselect) — Sends structured source context to LLMs.
 * [OpenAI Codex CLI](https://github.com/openai/codex) — Experimental terminal assistant.
 * [Gemini CLI](https://github.com/google-gemini/gemini-cli) — Terminal assistant built around Google Gemini.
+* [OpenPaw](https://github.com/daxaur/openpaw) — Turns Claude Code into a personal assistant with 38 skills for email, calendar, Spotify, smart home, and more.
 
 ---
 


### PR DESCRIPTION
**OpenPaw** ([GitHub](https://github.com/daxaur/openpaw)) is an open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.

Users describe what they want in natural language and Claude handles it, making it a natural fit for the vibe coding ecosystem. MIT licensed.

I'm the maintainer of OpenPaw and would love to see it included in this list.