### PR TITLE
Add agent-hub to AI-driven task management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) — Automatically turns big ideas into task queues.
 * [Claude Task Master](https://github.com/eyaltoledano/claude-task-master) — Compatible with popular AI IDEs, breaks down work into subtasks.
+* [agent-hub](https://github.com/Dominic789654/agent-hub) — Local-first multitask board for routing, sequencing, and observing repo-local coding agents across projects.
 
 ---
 
@@ -135,4 +136,3 @@ This list focuses on tools and workflows where AI plays a central role in the de
 ## Contributing
 
 Found something interesting or built your own tool? Contributions are encouraged—see the [contribution guide](CONTRIBUTING.md) for details.
-


### PR DESCRIPTION
## Summary
- add `agent-hub` to the AI-Driven Task Management section
- describe it as a local-first board for routing and observing repo-local coding agents

## Why it fits
`agent-hub` focuses on task routing, dependencies, retries, and visibility for code-assistant workflows, which fits the AI-driven task management category.
