### PR TITLE
Add Budi to new Monitoring & Cost Tracking section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Desktop & Local Apps](#desktop--local-apps)
 * [CLI Tools](#cli-tools)
 * [AI-Driven Task Management](#ai-driven-task-management)
+* [Monitoring & Cost Tracking](#monitoring--cost-tracking)
 * [Project Documentation](#project-documentation)
 * [Articles & Updates](#articles--updates)
 * [Contributing](#contributing)
@@ -106,6 +107,12 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) — Automatically turns big ideas into task queues.
 * [Claude Task Master](https://github.com/eyaltoledano/claude-task-master) — Compatible with popular AI IDEs, breaks down work into subtasks.
+
+---
+
+## Monitoring & Cost Tracking
+
+* [Budi](https://github.com/siropkin/budi) — Local-first cost analytics for AI coding agents. Tracks token usage and spend across Claude Code and Cursor.
 
 ---
 


### PR DESCRIPTION
## Add Budi

[Budi](https://github.com/siropkin/budi) is a local-first cost analytics tool for AI coding agents. It tracks token usage and spend across Claude Code and Cursor, helping developers understand where their AI money goes.

### Why a new category?

The list covers tools for *building with AI* but nothing for *monitoring the cost of building with AI*. As AI coding agents become mainstream, cost visibility is increasingly important. A "Monitoring & Cost Tracking" section fills this gap and could grow as more tools emerge in this space.

### Changes

- Added "Monitoring & Cost Tracking" section to the table of contents
- Added the new section with Budi as the first entry, placed after "AI-Driven Task Management"