### PR TITLE
Add Bernstein to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [CodeSelect](https://github.com/maynetee/codeselect) — Sends structured source context to LLMs.
 * [OpenAI Codex CLI](https://github.com/openai/codex) — Experimental terminal assistant.
 * [Gemini CLI](https://github.com/google-gemini/gemini-cli) — Terminal assistant built around Google Gemini.
+* [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [Bernstein](https://github.com/chernistry/bernstein) to the **CLI Tools** section
- Bernstein is a deterministic orchestrator for vibe coding at scale — it spawns parallel AI coding agents from a single goal, verifies with tests, and auto-commits

## Details

Bernstein fits naturally among the CLI tools listed here. It takes a different approach from single-agent assistants by orchestrating multiple AI coding agents in parallel, with built-in test verification and automatic commits.