### PR TITLE
feat: add ClaudeCode Launchpad CLI to Desktop & Local Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 ## Desktop & Local Apps
 
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
+* [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
 
 ---
 


### PR DESCRIPTION
## What's being added

**[ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal)** — a Windows & macOS installer and launcher for Claude Code.

Added to the **Desktop & Local Apps** section.

## Why it fits

ClaudeCode Launchpad CLI sits at the intersection of "vibe coding setup" and "desktop productivity" — it removes the 30+ minute manual configuration barrier that stops many Windows and macOS users from getting started with Claude Code:

- **2-minute setup** — auto-installs Node.js, Git, and Claude Code
- **Desktop shortcut + folder picker** — double-click and choose a project; no `cd` needed
- **Right-click context menu** — "Open with ClaudeCode Launchpad CLI" on any Windows folder
- **Two-line live status bar** — model, context %, total tokens, session/weekly usage bars with reset timers
- **Optional light-blue theme** and Claude flags support

Repo: https://github.com/noambrand/kivun-terminal