### PR TITLE
Add toprank — SEO + Google Ads plugin for Claude Code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [GitHub Copilot](https://github.com/features/copilot) — Integrated assistant offering code suggestions, chats, and context-aware actions.
 * [Amazon Q](https://aws.amazon.com/q/developer) — AWS’s generative AI solution for developers.
 * [Superdesign](https://www.superdesign.dev/) — AI design agent for fast UI iterations.
+* [toprank](https://github.com/nowork-studio/toprank) — Open-source Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and Google Ads API; ships meta tag and schema markup fixes to WordPress/Strapi/Contentful/Ghost. MIT, 107⭐.
 
 ---
 


### PR DESCRIPTION
Adds **toprank** under Extensions & Plugins. Open-source Claude Code plugin with 9 SEO and Google Ads skills. **107 ⭐, 14 🍴, MIT.**

- Source: https://github.com/nowork-studio/toprank