### PR TITLE
Add WhereMyTokens

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 ## Monitoring & Cost Tracking
 
 * [Budi](https://github.com/siropkin/budi) — Local-first cost analytics for AI coding agents. Tracks token usage and spend across Claude Code and Cursor.
+* [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Local-first Windows tray app for tracking Claude Code and Codex tokens, costs, sessions, cache, and rate limits.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add WhereMyTokens to Monitoring & Cost Tracking.
- It is a local-first Windows tray app for tracking Claude Code and Codex tokens, costs, sessions, cache, and rate limits.

## Notes
- Public GitHub repo, MIT licensed, actively maintained.
- Added as a concise single entry in the existing section format.