### PR TITLE
Add unslop — AI writing pattern remover for vibe-coded text

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Autohand Code CLI](https://github.com/autohandai/code-cli) — Self-evolving autonomous coding agent for the terminal with 40+ tools, multi-LLM support, and a modular skills system.
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
+* [unslop](https://github.com/MohamedAbdallah-14/unslop) — CLI and MCP server that removes AI writing patterns from text. Detects tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Five intensity levels and a lint-only audit mode. Useful for cleaning commit messages, PR descriptions, and vibe-coded documentation.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
 
 ---


### PR DESCRIPTION
Adds unslop to the CLI Tools section.

**unslop** is a CLI and MCP server that removes AI writing patterns from text. Relevant to vibe coding workflows where AI-generated commit messages, PR descriptions, and documentation often carry detectable patterns. Tricolons, em-dash overuse, hedging stacks, sycophancy openers. Five intensity levels from conservative to aggressive, plus a lint-only audit mode for passive inspection without modifying output.

- Npm: `npx unslop`
- Pip: `pip install unslop`
- MIT licensed
- https://github.com/MohamedAbdallah-14/unslop
