### PR TITLE
Add Septim Agents Pack to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [Septim Agents Pack](https://septimlabs.com/tools/agents?utm_source=awesome-vibe-coding&utm_medium=awesome-list&utm_campaign=oss-backlink) — 10 named Claude Code sub-agents (Atlas through Pip) for structured vibe coding sessions: each agent owns a domain (planning, architecture, brand, marketing, finance, design, legal, customer, research, coordination). Drop `.claude/agents/` into any project.
 
 ---
 


### PR DESCRIPTION
## What this adds

**[Septim Agents Pack](https://septimlabs.com/tools/agents?utm_source=awesome-vibe-coding&utm_medium=awesome-list&utm_campaign=oss-backlink)** — 10 named Claude Code sub-agents, each covering a distinct functional domain: planning, architecture, brand, marketing/copy, finance/pricing, design, legal, customer/onboarding, research, and cross-agent coordination. They are invoked via the Claude Code CLI by dropping `.md` files into `.claude/agents/`.

## Why it fits this list

The CLI Tools section lists tools that work with Claude Code in the terminal — `memov` (memory layer), `OpenPaw` (38 skills for Claude Code), `Autohand Code CLI` (modular skills system). Septim Agents Pack is the same pattern: a role-specialised layer on top of Claude Code, invoked from the terminal, that structures long vibe-coding sessions by giving each type of decision its own named agent.

## Format check

- Added to end of CLI Tools section, before `---`
- Format matches existing entries: `* [Name](URL) — Description.`
- No emojis, factual description only
- UTM params on URL for attribution

## Live product page

https://septimlabs.com/tools/agents