### PR TITLE
Add Parallel Code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
+* [Parallel Code](https://github.com/johannesjo/parallel-code) — Desktop app for running Claude Code, Codex CLI, and Gemini CLI side by side in separate git worktrees, with diff review and merge controls.
 
 ---
 


### PR DESCRIPTION
Adds Parallel Code to Desktop & Local Apps. It runs Claude Code, Codex CLI, and Gemini CLI side by side in separate git worktrees.