### PR TITLE
Add ArcadeLab

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [MyVibe](https://myvibe.so/) — Instant deployment for AI-generated web apps. Publish via Claude Code skills or direct upload.
 * [Rosebud AI](https://rosebud.ai) — Vibe coding platform for creating 3D games and interactive web apps with AI.
 * [Forge](https://forge-web.rebaselabs.online/) — AI-powered full-stack app creator with BYOK (bring your own API key). Multi-stage pipeline: planning, architecture, code generation, and verification.
+* [ArcadeLab](https://arcadelab.ai/) — Free no-signup hosting for AI-generated single-file HTML games, visualizations, and interactive content. Paste a complete HTML file, get a permanent shareable URL.
 
 ---
 


### PR DESCRIPTION
Adding ArcadeLab to Web-Based Builders.

**[ArcadeLab](https://arcadelab.ai/)** is a free no-signup hosting platform for AI-generated single-file HTML content — games, visualizations, simulations, and interactive explainers. Creators (using Claude, ChatGPT, Cursor, Bolt, etc.) paste a complete HTML file at arcadelab.ai/publish and get a permanent shareable URL. No account, no email, no build tools.

Why it fits the list:
- Sibling to MyVibe and FlyPloy (already in Web-Based Builders) — purpose-built for deploying AI-generated apps
- Specifically designed for the single-HTML-file format that vibe-coding sessions produce
- Free + open source ([github.com/mlapeter/arcadelab](https://github.com/mlapeter/arcadelab))
- Example interactive demo: [double-slit experiment](https://arcadelab.ai/play/light-wave-or-particle-ultraviper34)

Added at bottom of Web-Based Builders. Followed the format `* [Name](link) — Description.` matching existing entries.