### PR TITLE
feat: add Mneme HQ to CLI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [Mneme HQ](https://github.com/TheoV823/mneme) — Architectural governance layer for AI-assisted development. Injects project decisions into LLM workflows and blocks architectural violations before generation. Works with Claude Code, Cursor, and agent frameworks.
 
 ---
 


### PR DESCRIPTION
**[Mneme HQ](https://github.com/TheoV823/mneme)** — architectural governance layer for AI-assisted development.

Added to **CLI Tools**, after VibeGrid.

Mneme HQ enforces architectural decisions on every AI coding assistant call. It deterministically retrieves relevant project decisions from `project_memory.json` and injects them into the LLM system prompt before generation, then detects constraint and anti-pattern violations in the output. Works with Claude Code, Cursor, Cline, and agent frameworks. No vector store, no ML dependencies, pip-installable.

- **License**: MIT
- **Language**: Python 3.11+