### PR TITLE
Add Agent FM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 ## Desktop & Local Apps
 
+* [Agent FM](https://github.com/agentfm-ai/agent-fm) — Local, open-source macOS app for listening to Claude Code and Codex agents as they work, with Global Mix, blocker alerts, and BYOK narration.
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
 


### PR DESCRIPTION
Adds Agent FM, a local/open-source macOS companion for Claude Code and Codex sessions.

Agent FM does not replace the coding agent runtime. It turns useful local session activity — progress, blockers, decisions, errors, and attention requests — into live narration. Developers can tune into one agent or listen to a Global Mix across active agents.

I added it under Desktop & Local Apps because it fits as a companion/awareness tool for developers running multiple local coding agents.