### PR TITLE
Add codex-profiles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [codex-profiles](https://github.com/Ducksss/codex-profiles) — Bash CLI for running Codex CLI and Desktop with named isolated `CODEX_HOME` profiles, so work, personal, education, or client accounts keep separate auth, config, sessions, connectors, and logs.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds codex-profiles to the CLI Tools section. It is a small Bash CLI for running OpenAI Codex CLI and Desktop with named isolated CODEX_HOME profiles, so developers can keep work, personal, education, or client Codex accounts separate without copying token files.

## Validation

- Ran `git diff --check`.