### PR TITLE
Add RapidNative to Mobile Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [VibeCode](https://www.vibecodeapp.com/) — A mobile-first app creator powered by AI.
 * [IM.codes](https://github.com/im4codes/imcodes) — Mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents.
+* [RapidNative](https://rapidnative.com/) — Turns ideas, sketches, or screenshots into working React Native and Expo apps with production-ready code you can view, edit, and extend.
 
 ---
 


### PR DESCRIPTION
## Adding RapidNative

Submitting [RapidNative](https://rapidnative.com/) to the **Mobile Tools** section.

### About
AI-native mobile app builder. Describe or sketch your app, watch it build in real time with team collaboration, then ship to App Store / Play Store. Generates production-ready React Native and Expo code that can be viewed, edited, and extended.

### Pricing
Freemium — 20 free credits to start.

### Fit
The Mobile Tools section currently has just 2 entries. RapidNative is a mobile-first AI app builder, sitting naturally next to VibeCode and complementing the React Native angle that's currently missing.

Thanks for maintaining this list!