### PR TITLE
Add WithVibe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [WithVibe](https://github.com/withvibe/withvibe) — Self-hostable shared AI dev environment for teams. Spin up an isolated, code-seeded env, build with AI, share the live session; an agent gate (security, code review, tests, policy) plus human approval reviews every change before it ships. Source-available; CLI via `npm install -g withvibe`.
 
 ---
 


### PR DESCRIPTION
Adds **WithVibe** to the CLI Tools section.

WithVibe is a self-hostable shared AI dev environment for teams: anyone spins up an isolated, code-seeded env and builds features with AI; an agent gate (security, code review, tests, policy) plus human approval reviews every change before it ships. Source-available; CLI via `npm install -g withvibe`.

- Repo: https://github.com/withvibe/withvibe
- Site: https://withvibe.dev

Entry appended to the end of the section, matching the existing `* [Name](url) — description` format.