### PR TITLE
Add HagiCode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
+* [HagiCode](https://hagicode.com/) — Local-first AI coding workspace with proposal workflows, parallel multi-agent execution, and multi-repository coordination.
 
 ---
 


### PR DESCRIPTION
Adds HagiCode to `Desktop & Local Apps`.

HagiCode is a local-first AI coding workspace with proposal workflows, parallel multi-agent execution, and multi-repository coordination.