### PR TITLE
Add Cate to Editors and IDEs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Cursor](https://www.cursor.com/) — One of the most advanced AI-first code editors.
 * [Zed](https://zed.dev/) — Built for real-time team collaboration with AI assistance.
 * [Amazon Kiro](https://kiro.dev) — An AI-powered IDE from prototype to production.
+* [Cate](https://github.com/0-AI-UG/cate) - Open source desktop IDE on an infinite zoomable canvas. You spread editors, terminals, browsers, and Claude Code agent panels across spatial workspace instead of tabs. Electron, MIT, macOS/Windows/Linux.
 
 ---
 


### PR DESCRIPTION
Adds Cate to Editors and IDEs. Cate is an open source desktop IDE built on an infinite canvas. It runs Claude Code agents in panels next to Monaco editors, terminals, and embedded browsers, so you can watch and steer several agents at once. MIT licensed, around 1300 stars, actively developed.
