### PR TITLE
Add Wikivibe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [CodeGuide](https://www.codeguide.dev/) — Tool that builds documentation for AI-built projects.
 * [LynxPrompt](https://github.com/GeiserX/LynxPrompt) — Self-hostable AI config management platform for teams. Manages AGENTS.md, CLAUDE.md, .cursor/rules/, slash commands, and 30+ formats.
 * [Claude Code Mastery](https://github.com/ShipWithAI/claude-code-mastery) — Structured course for mastering Claude Code workflows, including security, automation, and multi-agent patterns.
+* [Wikivibe](https://wikivibe.ru/en/) — Practical knowledge base for AI-assisted development with guides, a glossary, jobs, and a public MCP endpoint.
 
 ---
 


### PR DESCRIPTION
Adds Wikivibe to the Project Documentation section as a practical AI-assisted development knowledge base with guides, glossary, jobs, and a public MCP endpoint.

Checked: link opens successfully at https://wikivibe.ru/en/.