### PR TITLE
Add Codex First Task Prompt Generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Bernstein](https://github.com/chernistry/bernstein) — Deterministic orchestrator for vibe coding at scale. Spawns parallel AI coding agents from a single goal, verifies with tests, auto-commits.
 * [sober-coding](https://github.com/voidborne-d/sober-coding) — Vibe code quality analyzer. 27 checks across security, architecture, duplication, error handling, dependencies, testing, and dead code. Language-agnostic with fix suggestions and CI mode.
 * [VibeGrid](https://github.com/jcanizalez/vibegrid) — Multi-agent terminal manager with task queues, workflow automation, and inline diff review.
+* [Codex First Task Prompt Generator](https://ronnie2025.github.io/ai-agent-workbench-starter-pack/codex-first-task-prompt-generator.html) — Free tool that turns a Codex CLI project goal into a scoped first-task prompt with constraints and acceptance checks.
 
 ---
 


### PR DESCRIPTION
Adds Codex First Task Prompt Generator to the CLI Tools section.\n\nWhy it fits:\n- Free and publicly accessible.\n- Helps developers start a Codex CLI vibe-coding task with a scoped first prompt.\n- Generates constraints and acceptance checks so the first agent task is easier to run and verify.\n- Added as a single line matching the existing list format.