### PR TITLE
Add Roblox GUI Maker

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [MyVibe](https://myvibe.so/) — Instant deployment for AI-generated web apps. Publish via Claude Code skills or direct upload.
 * [Rosebud AI](https://rosebud.ai) — Vibe coding platform for creating 3D games and interactive web apps with AI.
 * [Forge](https://forge-web.rebaselabs.online/) — AI-powered full-stack app creator with BYOK (bring your own API key). Multi-stage pipeline: planning, architecture, code generation, and verification.
+* [Roblox GUI Maker](https://robloxguimaker.dev/) — Generate Roblox Studio GUI layouts and Lua starter code from prompts.
 
 ---
 


### PR DESCRIPTION
Adds Roblox GUI Maker to the Web-Based Builders section. The tool generates Roblox Studio GUI layouts and Lua starter code from prompts.