### PR TITLE
feat: add NotFair — Claude Code skills for SEO, Google Ads, and Meta Ads

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [Amazon Q](https://aws.amazon.com/q/developer) — AWS’s generative AI solution for developers.
 * [Superdesign](https://www.superdesign.dev/) — AI design agent for fast UI iterations.
 * [toprank](https://github.com/nowork-studio/toprank) — Open-source Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and Google Ads API; ships meta tag and schema markup fixes to WordPress/Strapi/Contentful/Ghost. MIT, 107⭐.
+* [NotFair](https://github.com/nowork-studio/NotFair) — Open-source Claude Code skills for [SEO](https://github.com/nowork-studio/NotFair/tree/main/seo), [Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads), and [Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads). Connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. MIT, ~2.9k⭐.
 * [dbForge AI Assistant](https://www.devart.com/dbforge/ai-assistant/) - Integrated AI tool that generates, optimizes, explains, and fixes SQL queries. 
 * [Frontman](https://github.com/frontman-ai/frontman) — Open-source AI agent that lives in your browser — click any element, describe changes in plain English, and get real code edits with hot reload. Works with Next.js, Vite, and Astro.
 * [Mysti](https://github.com/DeepMyst/Mysti) - Multi-agent AI coding assistant for VS Code with brainstorm mode. Supports Claude Code, Codex, Gemini, Cline, and GitHub Copilot.


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code agent skills covering SEO, Google Ads, and Meta Ads — around ~2.9k stars. It fits naturally in the Extensions & Plugins section alongside the existing toprank entry (also from nowork-studio, a related but distinct project).

NotFair provides skills for site analysis, keyword research, meta tags, schema markup, GEO optimization, Google Ads audits, wasted-spend detection, and Meta Ads ROAS/creative analysis. It connects to live account data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

Happy to reword the entry, adjust placement, or trim anything — just let me know.