### PR TITLE
Add Playcode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 * [MyVibe](https://myvibe.so/) — Instant deployment for AI-generated web apps. Publish via Claude Code skills or direct upload.
 * [Rosebud AI](https://rosebud.ai) — Vibe coding platform for creating 3D games and interactive web apps with AI.
 * [Forge](https://forge-web.rebaselabs.online/) — AI-powered full-stack app creator with BYOK (bring your own API key). Multi-stage pipeline: planning, architecture, code generation, and verification.
+* [Playcode](https://playcode.io/ai-website-builder) - AI website and app builder with visual editing, hosting, and custom domains.
 
 ---
 


### PR DESCRIPTION
Adds Playcode to Web-Based Builders. It fits the section as a prompt-based website and app builder with hosted output and visual editing.

Checks:
- Added one README entry only
- Kept the existing list format
- Ran git diff --check