### PR TITLE
Add LoopTroop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ This list focuses on tools and workflows where AI plays a central role in the de
 
 * [Dyad](https://www.dyad.sh/) — A lightweight, local platform for creating AI-driven apps without depending on the cloud.
 * [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) — Windows & macOS installer and launcher for Claude Code. 2-minute setup: auto-installs Node.js, Git & Claude Code; adds a live two-line status bar (model, context %, usage limits), desktop shortcut with folder picker, and right-click "Open with ClaudeCode Launchpad CLI" context menu on Windows folders.
+* [LoopTroop](https://github.com/looptroop-ai/LoopTroop) — Local, open-source GUI that orchestrates AI coding agents from ticket to PR. An LLM council plans, work runs in isolated git worktrees, and a Ralph loop resets the worktree and retries on failure to fight context rot. Built on OpenCode.
 
 ---
 


### PR DESCRIPTION
I added LoopTroop under Desktop & Local Apps.

It's a local, open-source GUI I've been building that orchestrates AI coding agents from a ticket all the way to a reviewable PR. An LLM council plans the work, tasks run in isolated git worktrees, and a Ralph loop resets the worktree and retries from clean context when a run goes wrong, so long tasks don't fall apart from context rot. It's built on OpenCode.

Seemed like a natural fit next to Dyad in the local apps section. One entry at the end, matching the existing line format.

Repo: https://github.com/looptroop-ai/LoopTroop